### PR TITLE
prevent the menu change to move around content

### DIFF
--- a/js/customd41d.js
+++ b/js/customd41d.js
@@ -9,21 +9,24 @@ $(document).ready(function(){
         {
             if(!nav.hasClass('fixed'))
             {
+                var dummy = $('<div id="menu-dummy"></div>');
+                dummy[0].style.height = nav.height() + 'px';
+                dummy.insertAfter(nav);
                 nav.addClass('fixed');
-                nav.removeClass('absolute');
                 nav.css('display','none');
                 nav.fadeIn();
             }
         }else
         {
-            if(!nav.hasClass('absolute'))
+            if(nav.hasClass('fixed') && !nav.hasClass('isFading'))
             {
-                nav.addClass('absolute');
+                nav.addClass('isFading');
                 nav.fadeOut(function(e){
+                    $('#menu-dummy').remove();
                     nav.removeClass('fixed');
+                    nav.removeClass('isFading');
                     nav.css('display','block');
                 })
-                //nav.removeClass('fixed');
             }
         }
         if ($(this).scrollTop() > 70) {


### PR DESCRIPTION
when you scoll down then the menu becomes floating. With my latest
layout changes, this left a gap and the content would move up. When
you scroll up again the menu overlays the body.

This was fixed by not making the menu absolut after scrolling up.

However this fix still leaves us with an unpleasant bouncing artifact,
where the container moves up/down when the menu changes from being
at the top of the page, to the top of the screen. This commit fixes
the movement by teporarily filling the gap left by the menu with an
empty div of the same size.